### PR TITLE
Add auto-play button with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Flask-based chess web application with MongoDB-backed game library, annotation
 - **Debug JSON Viewer**: In the Annotations panel, see the full MongoDB JSON document for the loaded game.
 - **Refresh Annotations from DB**: Button in the Annotations panel to fetch the latest move annotations directly from MongoDB for the current game.
 - **Keyboard Navigation**: Use left/right arrows to step through moves.
+- **Auto-Play Moves**: Click the play button in the move panel to cycle through moves automatically.
 - **Download to PGN**: Export games or openings to PGN, including all annotations.
 
 ## Backend API

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,7 +8,8 @@
 - Home button now reliably returns to the startup page
 - Improved cheat panel UI: depth slider and label are now side by side for better usability
 - Unified sidebar menu: all pages now extend `base.html` and use a single menu definition for consistency
-- Move information panel: improved table, navigation controls, and new play button for auto-playback
+- Move information panel: improved table, navigation controls, and a new play button for auto-playback.
+  Click the play button to automatically cycle through moves; interacting with other controls stops playback.
 
 ### Engine & Analysis
 - All move generation, evaluation, and cheat suggestions powered by Stockfish

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -1447,7 +1447,8 @@ let isPlayingMoves = false;
 
 function setMoveNavDisabled(disabled) {
     const btns = [
-        '#moveNavFirst', '#moveNavBack', '#moveNavForward', '#moveNavLast', '#moveNavNumber', '#downloadPgnBtn', '#playMovesBtn'
+        '#moveNavFirst', '#moveNavBack', '#moveNavForward', '#moveNavLast',
+        '#moveNavNumber', '#downloadPgnBtn'
     ];
     btns.forEach(sel => {
         const el = document.querySelector(sel);
@@ -1499,9 +1500,7 @@ function playMoves() {
 document.addEventListener('DOMContentLoaded', function() {
     // ... existing code ...
     const playBtn = document.getElementById('playMovesBtn');
-    if (playBtn) {
-        playBtn.addEventListener('click', playMoves);
-    }
+    if (playBtn) playBtn.addEventListener('click', playMoves);
     // Stop playback if user interacts with nav
     ['moveNavFirst','moveNavBack','moveNavForward','moveNavLast','moveNavNumber'].forEach(id => {
         const el = document.getElementById(id);

--- a/templates/index.html
+++ b/templates/index.html
@@ -481,6 +481,9 @@
                                         <span id="moveNavTotal" style="font-size: 1.1em; color: #888;">/ 0</span>
                                         <button id="moveNavForward" class="move-nav-btn" title="Next Move"><span class="glyphicon glyphicon-chevron-right"></span></button>
                                         <button id="moveNavLast" class="move-nav-btn" title="Last Move"><span class="glyphicon glyphicon-step-forward"></span></button>
+                                        <button id="playMovesBtn" class="move-nav-btn" title="Auto-Play">
+                                            <span class="glyphicon glyphicon-play"></span>
+                                        </button>
                                         <button id="downloadPgnBtn" class="move-nav-btn" title="Import/Export PGN"><span class="glyphicon glyphicon-transfer"></span></button>
                                         <button id="annotationsBtn" class="move-nav-btn" title="Annotations" style="background: linear-gradient(90deg, #8e24aa 60%, #ce93d8 100%); color: #fff;">
                                             <span class="glyphicon glyphicon-comment"></span>


### PR DESCRIPTION
## Summary
- add auto-play button in the move navigation controls
- document new playback option in README and release notes
- keep play button active so users can stop playback

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python flask_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688545eaa760833089bd77e90ca50a71